### PR TITLE
Added check for empty DSC configuration

### DIFF
--- a/Modules/DSCParser.psm1
+++ b/Modules/DSCParser.psm1
@@ -86,6 +86,11 @@
             {
                 $i++
                 $newIndexPosition = $i+1
+                if ($null -eq $parsedData[$newIndexPosition])
+                {
+                    Write-Warning "The configuration might be empty, please check it."
+                    return
+                }
             }
         }
     }


### PR DESCRIPTION
The cmdlet would never break out of the loop if the Node configuration is empty

Fixes:
* https://github.com/microsoft/Microsoft365DSC/issues/1234
* #16