### PR TITLE
Fix for support for arrays of cim instances and few other improvements

### DIFF
--- a/DSCParser.psd1
+++ b/DSCParser.psd1
@@ -66,16 +66,16 @@ PowerShellVersion = '4.0'
 NestedModules = @("modules\DSCParser.psm1")
 
 # Functions to export from this module
-#FunctionsToExport = '*'
+FunctionsToExport = @("ConvertTo-DSCObject")
 
 # Cmdlets to export from this module
-CmdletsToExport = @("ConvertTo-DSCObject", "Get-VariableListFromDSC")
+CmdletsToExport = @()
 
 # Variables to export from this module
 #VariablesToExport = '*'
 
 # Aliases to export from this module
-#AliasesToExport = '*'
+AliasesToExport = @()
 
 # List of all modules packaged with this module
 # ModuleList = @()

--- a/Modules/DSCParser.psm1
+++ b/Modules/DSCParser.psm1
@@ -190,15 +190,19 @@ function Get-HashtableFromGroup
                     {
                         {$_ -in @("String","Number")} {
                             $result.$currentProperty += $component.Content
+                            break
                         }
                         {$_ -in @("Variable")} {
                             $result.$currentProperty += "`$" + $component.Content
+                            break
                         }
                         {$_ -in @("Member")} {
                             $result.$currentProperty += "." + $component.Content
+                            break
                         }
                         {$_ -in @("Comment")} {
                             $result.$("_metadata_" + $currentProperty) += $component.Content
+                            break
                         }
                         {$_ -in @("GroupStart")} {
 
@@ -223,6 +227,7 @@ function Get-HashtableFromGroup
                                         $currentPropertyIndex++
                                     }
                                     while ($group[$currentPropertyIndex].Type -ne 'GroupEnd')
+                                    break
                                 }
 
                                 # Property is an array of CIMInstance
@@ -250,8 +255,10 @@ function Get-HashtableFromGroup
                                     while ($group[$currentPropertyIndex-1].Type -ne 'GroupEnd' -or $GroupsToClose -ne 0 -or -not $FoundOneGroup)
                                     $CimInstanceObject = Convert-CIMInstanceToPSObject -CIMInstance $CimInstanceComponents
                                     $result.$CurrentProperty += $CimInstanceObject
+                                    break
                                 }
                             }
+                            break
                         }
                     }
                 }

--- a/Modules/DSCParser.psm1
+++ b/Modules/DSCParser.psm1
@@ -303,7 +303,7 @@ function Convert-CIMInstanceToPSObject
         $CIMInstance
     )
 
-    $result = @{}
+    $result = [ordered] @{}
     $index = 0
     $CurrentMemberName = $null
     while($index -lt $CimInstance.Count)

--- a/Modules/DSCParser.psm1
+++ b/Modules/DSCParser.psm1
@@ -93,7 +93,7 @@
     $ParsedResults = $null
     if ($componentsArray.Count -gt 0)
     {
-        $ParsedResults = Get-HashtableFromGroup -Groups $componentsArray -Path $Path
+        $ParsedResults = Get-HashtableFromGroup -Groups $componentsArray -Path $Path -IncludeComments:$IncludeComments.IsPresent
     }
     return $ParsedResults
 }
@@ -113,7 +113,9 @@ function Get-HashtableFromGroup
 
         [Parameter()]
         [System.Boolean]
-        $IsSubGroup = $false
+        $IsSubGroup = $false,
+
+        [switch] $IncludeComments
     )
 
     # Loop through all the Resources identified within our configuration
@@ -176,7 +178,7 @@ function Get-HashtableFromGroup
                         $currentPosition++
                     }
                     $currentPropertyIndex = $currentPosition
-                    $subResult = Get-HashtableFromGroup -Groups $allSubGroups -IsSubGroup $true -Path $Path
+                    $subResult = Get-HashtableFromGroup -Groups $allSubGroups -IsSubGroup $true -Path $Path -IncludeComments:$IncludeComments.IsPresent
                     $allSubGroups = @()
                     $subGroup = @()
                     $result.$currentProperty += $subResult
@@ -205,7 +207,9 @@ function Get-HashtableFromGroup
                             break
                         }
                         {$_ -in @("Comment")} {
-                            $result.$("_metadata_" + $currentProperty) += $component.Content
+                            if ($IncludeComments) {
+                                $result.$("_metadata_" + $currentProperty) += $component.Content
+                            }
                             break
                         }
                         {$_ -in @("GroupStart")} {

--- a/Modules/DSCParser.psm1
+++ b/Modules/DSCParser.psm1
@@ -134,7 +134,7 @@ function Get-HashtableFromGroup
             $component = $group[$currentPropertyIndex]
             if ($component.Type -eq "Keyword" -and -not $keywordFound)
             {
-                $result = @{ ResourceName = $component.Content }
+                $result = [ordered] @{ ResourceName = $component.Content }
                 $keywordFound = $true
             }
             elseif ($keywordFound)

--- a/Modules/DSCParser.psm1
+++ b/Modules/DSCParser.psm1
@@ -29,7 +29,7 @@
         $noisyTypesCore += "Comment"
     }
     $noisyOperators = (".",",", "")
-    
+
     # Tokenize the file's content to break it down into its various components;
     if (([System.String]::IsNullOrEmpty($Path) -and [System.String]::IsNullOrEmpty($Content)) -or `
         (![System.String]::IsNullOrEmpty($Path) -and ![System.String]::IsNullOrEmpty($Content)))
@@ -50,7 +50,7 @@
     $nodeKeyWordEncountered = $false
     $ObjectsToClose = 0
     for ($i = 0; $i -lt $parsedData.Count; $i++)
-    {    
+    {
         if ($nodeKeyWordEncountered)
         {
             if ($parsedData[$i].Type -eq "GroupStart" -or $parsedData[$i].Content -eq '{')
@@ -72,7 +72,7 @@
                     $ObjectsToClose = 0
                 }
             }
-            elseif (($parsedData[$i].Type -eq "GroupEnd" -and $parsedData[$i-2].Content -ne 'parameter' -and $parsedData[$i].Content -ne '}') -or 
+            elseif (($parsedData[$i].Type -eq "GroupEnd" -and $parsedData[$i-2].Content -ne 'parameter' -and $parsedData[$i].Content -ne '}') -or
                 ($parsedData[$i].Type -eq "GroupStart" -and $parsedData[$i-1].Content -ne 'parameter' -and $parsedData[$i].Content -ne '{'))
             {
                 $currentValues += $parsedData[$i]
@@ -167,7 +167,7 @@ function Get-HashtableFromGroup
                         {
                             $currentGroupEndFound = $true
                         }
-                        
+
                         if ($ObjectsToClose -eq 0 -and $group[$currentPosition].Type -ne 'Keyword')
                         {
                             $allSubGroups += ,$subGroup
@@ -249,7 +249,7 @@ function Get-HashtableFromGroup
                                     }
                                     while ($group[$currentPropertyIndex-1].Type -ne 'GroupEnd' -or $GroupsToClose -ne 0 -or -not $FoundOneGroup)
                                     $CimInstanceObject = Convert-CIMInstanceToPSObject -CIMInstance $CimInstanceComponents
-                                    $result.$CurrentProperty = $CimInstanceObject
+                                    $result.$CurrentProperty += $CimInstanceObject
                                 }
                             }
                         }
@@ -322,14 +322,14 @@ function Convert-CIMInstanceToPSObject
                 $result.$CurrentMemberName = $content
             }
             {$_ -eq "GroupStart" -and $token.Content -eq '@('} {
-                $result.$CurrentMemberName = @()                
+                $result.$CurrentMemberName = @()
                 $index++
                 while ($CimInstance[$index].Type -eq 'NewLine')
                 {
                     $index++
                 }
                 switch ($CIMInstance[$index].Type)
-                {                    
+                {
                     { $_ -in "String", "Number", "Variable"} {
                         $arrayContent = @()
                         do {
@@ -374,9 +374,9 @@ function Convert-CIMInstanceToPSObject
                             }
                             while ($CIMInstance[$index-1].Type -ne 'GroupEnd' -or $GroupsToClose -ne 0 -or -not $FoundOneGroup)
                             $CimInstanceObject = Convert-CIMInstanceToPSObject -CIMInstance $CimInstanceComponents
-                            $result.$CurrentMemberName += $CimInstanceObject  
+                            $result.$CurrentMemberName += $CimInstanceObject
                             $index++
-                        }                      
+                        }
                     }
                 }
             }

--- a/Modules/DSCParser.psm1
+++ b/Modules/DSCParser.psm1
@@ -200,6 +200,10 @@ function Get-HashtableFromGroup
                             $result.$currentProperty += "." + $component.Content
                             break
                         }
+                        {$_ -in @("Command")} {
+                            $result.ResourceID += $component.Content
+                            break
+                        }
                         {$_ -in @("Comment")} {
                             $result.$("_metadata_" + $currentProperty) += $component.Content
                             break

--- a/Modules/DSCParser.psm1
+++ b/Modules/DSCParser.psm1
@@ -101,7 +101,7 @@
 function Get-HashtableFromGroup
 {
     [CmdletBinding()]
-    [OutputType([System.Collections.Hashtable])]
+    [OutputType([System.Collections.IDictionary])]
     param(
         [Parameter(Mandatory = $true)]
         [System.Array]
@@ -296,7 +296,7 @@ function Get-HashtableFromGroup
 function Convert-CIMInstanceToPSObject
 {
     [CmdletBinding()]
-    [OutputType([System.Collections.Hashtable])]
+    [OutputType([System.Collections.IDictionary])]
     Param(
         [Parameter(Mandatory = $true)]
         [System.Object[]]

--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ DSCParser is available from the PowerShell Gallery, simply run:
 ```powershell
 Install-Module DSCParser
 ```
+
+## Usage
+
+```powershell
+$DSCObjects = ConvertTo-DSCObject -Path $PSScriptRoot\..\Tests\Templates\Template1.ps1 -IncludeComments $true
+$DSCObjects | Format-Table
+```


### PR DESCRIPTION
This PR:
- fixes an array of being overwritten #19 
- adds retaining of the order of the DSC objects the way user provided it
- adds breaks for the switch to stop unnecessary processing
- adds support for ResourceID (i think i can call it that)
- fixes IncludeComments parameter which wasn't doing anything (maybe should be converted to switch?)
- fixes PSD1 to expose only one function `ConvertTo-DSCObject` (it's not cmdlet, Get-VariableListFromDSC doesn't exists, and if you don't define FunctionsToExport, AliasesToExport it will use *). The rest of functions are private and should not be exposed. 
- Fixes issue with CIMInstances being treated as resources