### PR TITLE
Update to fix issue with sub-CIM

### DIFF
--- a/Modules/DSCParser.psm1
+++ b/Modules/DSCParser.psm1
@@ -473,6 +473,7 @@ function Convert-CIMInstanceToPSObject {
                 if (-not [System.String]::IsNullOrEmpty($CurrentMemberName))
                 {
                     $subCim = @()
+                    $subCim += $CimInstance[--$index]
                     $openedGroups = 0
                     $index++
                     while ($CimInstance[$index].Type -ne 'GroupEnd' -and $openedGroups -le 0)


### PR DESCRIPTION
With this diff the PSObject is added with the proper CIMInstance property on sub-CIM instances, this fixes both my issues reported on #31 and #32 and I'm not seeing any downsides on other resources.