### PR TITLE
Fix issue with nested CIM Instances

### DIFF
--- a/Modules/DSCParser.psm1
+++ b/Modules/DSCParser.psm1
@@ -473,13 +473,13 @@ function Convert-CIMInstanceToPSObject {
                 if (-not [System.String]::IsNullOrEmpty($CurrentMemberName))
                 {
                     $subCim = @()
-                    $subCim += $CimInstance[--$index]
-                    $openedGroups = 0
-                    $index++
-                    while ($CimInstance[$index].Type -ne 'GroupEnd' -and $openedGroups -le 0)
+                    $subCim += $CimInstance[$index-1]
+                    $subCim += $CimInstance[$index]
+                    $openedGroups = 1
+                    while ($openedGroups -gt 0)
                     {
-                        $subCim += $CimInstance[$index]
                         $index++
+                        $subCim += $CimInstance[$index]
                         if ($CimInstance[$index].Type -eq 'GroupStart')
                         {
                             $openedGroups++


### PR DESCRIPTION
This PR fixes an issue where nested CIM Instance were not processed successfully. As soon as an open brace was found in a nested instance, the code would stop resulting in an incomplete object. That resulted in the rest of the properties to be added to the parent object.

With this update the code is now processing the nested CIM Instances correctly.