### PR TITLE
ConvertTo-DSCObject: Convert bool to bool not to string

### DIFF
--- a/Modules/DSCParser/Modules/DSCParser.psm1
+++ b/Modules/DSCParser/Modules/DSCParser.psm1
@@ -457,7 +457,21 @@ function ConvertTo-DSCObject
                 }
                 elseif ($valueType -eq '[String]' -or $isVariable)
                 {
-                    $value = $value
+                    if ($isVariable -and [Boolean]::TryParse($value.TrimStart('$'), [ref][Boolean]))
+                    {
+                        if ($value -eq "`$true")
+                        {
+                            $value = $true
+                        }
+                        elseif ($value -eq "`$false")
+                        {
+                            $value = $false
+                        }
+                    }
+                    else
+                    {
+                        $value = $value
+                    }
                 }
                 elseif ($valueType -eq '[string[]]')
                 {

--- a/Modules/DSCParser/Modules/DSCParser.psm1
+++ b/Modules/DSCParser/Modules/DSCParser.psm1
@@ -463,7 +463,7 @@ function ConvertTo-DSCObject
                         {
                             $value = $true
                         }
-                        elseif ($value -eq "`$false")
+                        else
                         {
                             $value = $false
                         }


### PR DESCRIPTION
With the new version of DSCParser it seems that *ConvertTo-DSCObject* currently exports booleans as pure strings where it actually should export as booleans, this PR fixes that.