### PR TITLE
Fix parser

### DIFF
--- a/Modules/DSCParser/Modules/DSCParser.psm1
+++ b/Modules/DSCParser/Modules/DSCParser.psm1
@@ -11,6 +11,7 @@
         [Array]
         $ParsedObject
     )
+
     # Find the location of the Node token. This is to ensure
     # we only look at comments that come after.
     $i = 0
@@ -85,6 +86,7 @@ function ConvertFrom-CIMInstanceToHashtable
         [System.Boolean]
         $IncludeCIMInstanceInfo = $true
     )
+
     $SchemaJSONObject = $null
     # Case we have an array of CIMInstances
     if ($ChildObject.GetType().Name -eq 'PipelineAst')
@@ -323,6 +325,7 @@ function ConvertTo-DSCObject
         [System.Boolean]
         $IncludeCIMInstanceInfo = $true
     )
+
     $result = @()
     $Tokens      = $null
     $ParseErrors = $null
@@ -333,7 +336,7 @@ function ConvertTo-DSCObject
         $Content = Get-Content $Path -Raw
     }
     $AST = [System.Management.Automation.Language.Parser]::ParseInput($Content, [ref]$Tokens, [ref]$ParseErrors)
-    
+
     # Look up the Configuration definition ("")
     $Config = $AST.Find({$Args[0].GetType().Name -eq 'ConfigurationDefinitionAst'}, $False)
 
@@ -350,7 +353,7 @@ function ConvertTo-DSCObject
             {
                 if ($statement.CommandElements[$i].ParameterName -eq 'ModuleName' -and `
                     ($i+1) -lt $statement.CommandElements.Count)
-                {         
+                {
                     $moduleName = $statement.CommandElements[$i+1].Value      
                     $currentModule.Add('ModuleName', $moduleName)
                 }
@@ -396,7 +399,7 @@ function ConvertTo-DSCObject
     catch
     {
         $resourceInstances = $Config.Body.ScriptBlock.EndBlock.Statements | Where-Object -FilterScript {$null -ne $_.CommandElements -and $_.CommandElements[0].Value -ne 'Import-DscResource'}
-    }        
+    }
 
     # Get the name of the configuration.
     $configurationName = $Config.InstanceName.Value
@@ -543,8 +546,8 @@ function ConvertTo-DSCObject
                     }
                 }
                 else
-                {   
-                    $isArray = $false                
+                {
+                    $isArray = $false
                     if ($keyValuePair.Item2.ToString().StartsWith('@('))
                     {
                         $isArray = $true


### PR DESCRIPTION
I was finally able to update DSCParser to v2 and put it through its passes with my unit/integration tests, I tested it before but only very briefly.

With that being said I found out a few issues which this PR tries to solve:

- When arrays of CIM instances are found if they only have one member then the resulting object doesn't count it as an array, this is not a problem per se but it screws up our module so I always convert these objects to arrays

- Already had a fix merged before for converting bools to bools instead of to strings but forgot to add similar logic for these type of properties inside CIM instances, this adds the logic there

- The last one is gross but I don't see any other way to do it right now which is on string arrays inside CIM instances to convert them to string then replace any final ', " or , to "`r`n" and then finally split the string in order to get back a string array

@NikCharlebois: Please note that our pipelines rely on a module that uses DSCParser and whenever there's a change here even if small I always have to refactor our module and a couple of times I already had to start from scratch, and to cope with this v2 was no different because I cannot upgrade M365DSC until I have DSCParser and my module working in sync