### PR TITLE
Bug fix: make sure write-progress does not go higher than 100%. Fixes #46

### DIFF
--- a/Modules/DSCParser/Modules/DSCParser.psm1
+++ b/Modules/DSCParser/Modules/DSCParser.psm1
@@ -1,4 +1,4 @@
-﻿function Update-DSCResultWithMetadata
+function Update-DSCResultWithMetadata
 {
     [CmdletBinding()]
     [OutputType([Array])]
@@ -22,7 +22,7 @@
 
     for ($i = $tokenPositionOfNode; $i -le $tokens.Length; $i++)
     {
-        $percent = ($i / ($tokens.Length - $tokenPositionOfNode) * 100)
+        $percent = (($i - $tokenPositionOfNode) / ($tokens.Length - $tokenPositionOfNode) * 100)
         Write-Progress -Status "Processing $percent%" `
                        -Activity "Parsing Comments" `
                        -PercentComplete $percent


### PR DESCRIPTION
DSCParser 2.0.0.3 has a bug that makes it throw an exception (message below). This pull request fixes that.

Update-DSCResultWithMetadata : Cannot validate argument on parameter 'PercentComplete'. The 101 argument is greater 
than the maximum allowed range of 100. Supply an argument that is less than or equal to 100 and then try the command 
again.
At D:\a\1\PSModules\DSCParser\2.0.0.3\Modules\DSCParser.psm1:535 char:19
+         $result = Update-DSCResultWithMetadata -Tokens $Tokens `
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Update-DSCResultWithMetadata], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationError,Update-DSCResultWithMetadata
 
