### PR TITLE
Fixed issue where strings are split on spaces instead of comma, when schema lists property as an array.

### DIFF
--- a/Modules/DSCParser/Modules/DSCParser.psm1
+++ b/Modules/DSCParser/Modules/DSCParser.psm1
@@ -246,8 +246,7 @@ function ConvertFrom-CIMInstanceToHashtable
                 elseif ($associatedCIMProperty.CIMType -eq 'stringArray' -or `
                         $associatedCIMProperty.CIMType -eq 'string[]')
                 {
-                    $subExpression = $subExpression.ToString().Replace("',`"", "`r`n").Replace("`",'", "`r`n").Replace("`",`"", "`r`n").Replace("',`'", "`r`n").Replace("',", "`r`n").Replace("`"", "`r`n")
-                    $subExpression = (-split $subExpression).Trim("`"").Trim("'")
+                    $subExpression = ($subExpression.ToString() -split ",").Trim("`"").Trim("'")
                     $currentResult.Add($entry.Item1.ToString(), $subExpression)
                 }
                 elseif ($associatedCIMProperty.CIMType -eq 'boolean' -and `


### PR DESCRIPTION
The current code was always splitting strings on spaces whenever the schema listed the property as a stringarray. This meant that all strings, even actual string arrays, were always split on spaces.

Updated the code to split on comma, which not makes sure multi values are correctly split.