### PR TITLE
Update line ending detection on configuration name replace

### DIFF
--- a/Modules/DSCParser/Modules/DSCParser.psm1
+++ b/Modules/DSCParser/Modules/DSCParser.psm1
@@ -434,7 +434,7 @@ function ConvertTo-DSCObject
     }
     if ($start -ge 0)
     {
-        $end = $Content.IndexOf("`r`n", $start)
+        $end = $Content.IndexOf("`n", $start)
         if ($end -gt $start)
         {
             $start = $Content.ToLower().IndexOf(' ', $start+1)


### PR DESCRIPTION
@NikCharlebois 

This Pull Request updates the behavior for the next line ending detection when trying to replace the configuration name in `ConvertTo-DscObject`. The next line ending is checked for carriage return + line feed, but the line might only contain a line feed without carriage return (e.g. when using `M365DSCRuleEvaluation`, which contains an inline configuration definition which is only made of line feeds, without the carriage returns). 

Without that updated line feed detection, not only the configuration name will be replaced, but everything down to the first resource definition, which then results in an incorrectly parsed DSC configuration. 