### PR TITLE
Fix infinite loop in nested CIM instance detection

### DIFF
--- a/Modules/DSCParser/Modules/DSCParser.psm1
+++ b/Modules/DSCParser/Modules/DSCParser.psm1
@@ -284,9 +284,9 @@ function ConvertFrom-CIMInstanceToHashtable
                             $regex = "'\s*,\s*'|`"\s*,\s*'|'\s*,\s*`"|`"\s*,\s*`""
                             [array]$regexResult = [Regex]::Split($subExpression, $regex)
 
-                            for ($i = 0; $i -lt $regexResult.Count; $i++)
+                            for ($j = 0; $j -lt $regexResult.Count; $j++)
                             {
-                                $regexResult[$i] = $regexResult[$i].Trim().Trim("'").Trim('"')
+                                $regexResult[$j] = $regexResult[$j].Trim().Trim("'").Trim('"')
                             }
 
                             $currentResult.Add($entry.Item1.ToString(), $regexResult)


### PR DESCRIPTION
This PR fixes an infinite loop with a reused `$i` variable inside of a nested loop. The current outer loop iterator `$i` was reassigned in the nested loop, leading to infinite executions. The inner loop variable was renamed to `$j`.

- Fixes https://github.com/microsoft/Microsoft365DSC/issues/5120