### PR TITLE
Add workaround for SInt32{Array} WMI data types

### DIFF
--- a/Modules/DSCParser/Modules/DSCParser.psm1
+++ b/Modules/DSCParser/Modules/DSCParser.psm1
@@ -359,7 +359,7 @@ function ConvertFrom-CIMInstanceToHashtable
                     {
                         $valueType = $associatedCIMProperty.CIMType
 
-                        # SInt32 is a WMI data types that PowerShell doesn't have so it requires this workaround
+                        # SInt32 is a WMI data type that PowerShell doesn't have so it requires this workaround
                         if ($valueType -eq "SInt32")
                         {
                             $valueType = "Int32"
@@ -651,7 +651,7 @@ function ConvertTo-DSCObject
                     $valueType -ne '[string[]]' -and `
                     -not $isVariable)
                 {
-                    # SInt32 is a WMI data types that PowerShell doesn't have so it requires this workaround
+                    # SInt32 is a WMI data type that PowerShell doesn't have so it requires this workaround
                     if ($valueType -eq "[SInt32]")
                     {
                         $valueType = "[Int32]"

--- a/Modules/DSCParser/Modules/DSCParser.psm1
+++ b/Modules/DSCParser/Modules/DSCParser.psm1
@@ -656,7 +656,7 @@ function ConvertTo-DSCObject
                     {
                         $valueType = "[Int32]"
                     }
-                    elseif ($valueType -eq "SInt32Array")
+                    elseif ($valueType -eq "[SInt32Array]")
                     {
                         $valueType = "[Int32[]]"
                     }

--- a/Modules/DSCParser/Modules/DSCParser.psm1
+++ b/Modules/DSCParser/Modules/DSCParser.psm1
@@ -271,7 +271,11 @@ function ConvertFrom-CIMInstanceToHashtable
                     $currentResult.Add($entry.Item1.ToString(), $subResult)
                 }
                 elseif ($associatedCIMProperty.CIMType -eq 'stringArray' -or `
-                        $associatedCIMProperty.CIMType -eq 'string[]')
+                        $associatedCIMProperty.CIMType -eq 'string[]' -or `
+                        $associatedCIMProperty.CIMType -eq 'SInt32Array' -or `
+                        $associatedCIMProperty.CIMType -eq 'SInt32[]' -or `
+                        $associatedCIMProperty.CIMType -eq 'UInt32Array' -or `
+                        $associatedCIMProperty.CIMType -eq 'UInt32[]')
                 {
                     if ($subExpression -is [System.String])
                     {
@@ -355,14 +359,10 @@ function ConvertFrom-CIMInstanceToHashtable
                     {
                         $valueType = $associatedCIMProperty.CIMType
 
-                        # SInt32{Array} are WMI data types that PowerShell doesn't have so it requires this workaround
+                        # SInt32 is a WMI data types that PowerShell doesn't have so it requires this workaround
                         if ($valueType -eq "SInt32")
                         {
                             $valueType = "Int32"
-                        }
-                        elseif ($valueType -eq "SInt32Array")
-                        {
-                            $valueType = "Int32[]"
                         }
 
                         # Try to parse the value based on the retrieved type.
@@ -651,14 +651,10 @@ function ConvertTo-DSCObject
                     $valueType -ne '[string[]]' -and `
                     -not $isVariable)
                 {
-                    # SInt32{Array} are WMI data types that PowerShell doesn't have so it requires this workaround
+                    # SInt32 is a WMI data types that PowerShell doesn't have so it requires this workaround
                     if ($valueType -eq "[SInt32]")
                     {
                         $valueType = "[Int32]"
-                    }
-                    elseif ($valueType -eq "[SInt32Array]")
-                    {
-                        $valueType = "[Int32[]]"
                     }
 
                     # Try to parse the value based on the retrieved type.


### PR DESCRIPTION
This PR fixes the issue I reported on #56, SInt32{Array} are both data types that only exist in WMI and must be converted to their equivalents in PowerShell, *Int32* and *Int32[]* respectively.