### PR TITLE
Add configuration validation during parsing

### DIFF
--- a/Modules/DSCParser/Modules/DSCParser.psm1
+++ b/Modules/DSCParser/Modules/DSCParser.psm1
@@ -466,10 +466,10 @@ function ConvertTo-DSCObject
     {
         if ($parseError -like "Could not find the module*" -or $parseError -like "Undefined DSC resource*")
         {
-            continue
+            Write-Warning -Message "$($errorPrefix)Failed to find module or DSC resource: $parseError"
         }
 
-        Write-Warning -Message "$($errorPrefix)Error parsing configuration: $parseError"
+        throw "$($errorPrefix)Error parsing configuration: $parseError"
     }
 
     # Look up the Configuration definition ("")

--- a/Modules/DSCParser/Modules/DSCParser.psm1
+++ b/Modules/DSCParser/Modules/DSCParser.psm1
@@ -438,8 +438,10 @@ function ConvertTo-DSCObject
     $ParseErrors = $null
 
     # Use the AST to parse the DSC configuration
+    $errorPrefix = ""
     if (-not [System.String]::IsNullOrEmpty($Path) -and [System.String]::IsNullOrEmpty($Content))
     {
+        $errorPrefix = "$Path - "
         $Content = Get-Content $Path -Raw
     }
 
@@ -459,6 +461,16 @@ function ConvertTo-DSCObject
     }
 
     $AST = [System.Management.Automation.Language.Parser]::ParseInput($Content, [ref]$Tokens, [ref]$ParseErrors)
+
+    foreach ($parseError in $ParseErrors)
+    {
+        if ($parseError -like "Could not find the module*" -or $parseError -like "Undefined DSC resource*")
+        {
+            continue
+        }
+
+        Write-Warning -Message "$($errorPrefix)Error parsing configuration: $parseError"
+    }
 
     # Look up the Configuration definition ("")
     $Config = $AST.Find({$Args[0].GetType().Name -eq 'ConfigurationDefinitionAst'}, $False)


### PR DESCRIPTION
This PR adds validation of the `ParseErrors` when running `ParseInput` on the supplied content in `ConvertTo-DSCObject`. Because invalid configurations and not defined resources should not be executed and checked anymore, we abort the execution. 