### PR TITLE
Add nested hashtable parsing inside of an array

### DIFF
--- a/Modules/DSCParser/Modules/DSCParser.psm1
+++ b/Modules/DSCParser/Modules/DSCParser.psm1
@@ -802,7 +802,7 @@ function ConvertFrom-DSCObject
                         {
                             [void]$results.AppendLine("$childSpacer    $property$additionalSpaces= `$$($entry.$property)")
                         }
-                        "Object\[\]|OrderedDictionary"
+                        "Object\[\]|OrderedDictionary|Hashtable"
                         {
                             if ($entry.$property.Length -gt 0)
                             {
@@ -811,7 +811,7 @@ function ConvertFrom-DSCObject
                                 {
                                     if ($objectToTest.'CIMInstance')
                                     {
-                                        if ($entry.$property.Length -gt 1)
+                                        if ($entry.$property -is [array])
                                         {
                                             $subResult = ConvertFrom-DSCObject -DSCResources $entry.$property -ChildLevel ($ChildLevel + 2)
                                             # Remove carriage return from last line
@@ -857,7 +857,7 @@ function ConvertFrom-DSCObject
                                         }
                                     }
                                 }
-                             }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This PR fixes an issue with nested CIM instances and array outputs when converting from a DSC resource to its string equivalent. 

Previously, nested CIM instances parsed from `ConvertTo-DSCObject` and reconverted to a string with `ConvertFrom-DSCObject` would miss the nested CIM instances when the output is generated. This is because the `|Hashtable` type was missing from the Regex filter. 

Another issue which will be fixed is that arrays with one element would not have been outputted as arrays, but rather just as a single instance. The Length check is replaced by a call to the property type, which is always `[array]` for properties that are any array type. 