### PR TITLE
Throw error if connection to the WinRM service fails

### DIFF
--- a/Modules/DSCParser/Modules/DSCParser.psm1
+++ b/Modules/DSCParser/Modules/DSCParser.psm1
@@ -190,6 +190,11 @@ function ConvertFrom-CIMInstanceToHashtable
                             {
                                 throw $_
                             }
+                            # If the connection to the WinRM service fails, inform the user to configure and enable it
+                            elseif ($_.Exception.Message -match 'The client cannot connect to the destination.*')
+                            {
+                                throw "Connection to the Windows Remote Management (WinRM) service failed. Please run ""winrm quickconfig"" or ""Enable-PSRemoting -Force -SkipNetworkProfileCheck"" to configure and enable it."
+                            }
                         }
                     } while ($firstTry)
                 }


### PR DESCRIPTION
Add an error message if the connection to the WinRM service fails, e.g. if the service isn't configured or enabled. This will most likely fix https://github.com/microsoft/Microsoft365DSC/issues/6040.