### PR TITLE
Fix missing CIM properties after update

### DIFF
--- a/Modules/DSCParser/Modules/DSCParser.psm1
+++ b/Modules/DSCParser/Modules/DSCParser.psm1
@@ -130,16 +130,29 @@ function ConvertFrom-CIMInstanceToHashtable
                                             -Namespace 'ROOT/Microsoft/Windows/DesiredStateConfiguration' `
                                             -ErrorAction SilentlyContinue
 
-                if ($null -eq $CIMClassObject)
+                $dscResourceInfo = $Script:DSCResources | Where-Object -FilterScript {$_.Name -eq $ResourceName}
+
+                if (-not $Script:MofSchemas.ContainsKey($ResourceName))
                 {
-                    if ($Script:IsPowerShellCore)
-                    {
-                        $dscResourceInfo = Get-PwshDscResource -Name $ResourceName
-                    }
-                    else
-                    {
-                        $dscResourceInfo = Get-DscResource -Name $ResourceName
-                    }
+                    $directoryName = Split-Path -Path $dscResourceInfo.ParentPath -Leaf
+                    $schemaPath = Join-Path -Path $dscResourceInfo.ParentPath -ChildPath "$directoryName.schema.mof"
+                    $mofSchema = Get-Content -Path $schemaPath -Raw
+                    $Script:MofSchemas[$ResourceName] = $mofSchema
+                }
+                else
+                {
+                    $mofSchema = $Script:MofSchemas[$ResourceName]
+                }
+
+                $pattern = "\[ClassVersion\(""([^""]+)""\)\]\s*class $CIMInstanceName\b"
+                if ($mofSchema -match $pattern) {
+                    $classVersion = [version]$matches[1]
+                } else {
+                    $classVersion = [version]"1.0.0.0"
+                }
+
+                if ($null -eq $CIMClassObject -or [Version]$CIMClassObject.CimClassQualifiers.Value -lt $classVersion)
+                {
                     $InvokeParams = @{
                         Name        = $ResourceName
                         Method      = 'Get'
@@ -507,7 +520,8 @@ function ConvertTo-DSCObject
             $ModulesToLoad += $currentModule
         }
     }
-    $DSCResources = @()
+    $Script:DSCResources = @()
+    $Script:MofSchemas = @{}
     foreach ($moduleToLoad in $ModulesToLoad)
     {
         $loadedModuleTest = Get-Module -Name $moduleToLoad.ModuleName -ListAvailable | Where-Object -FilterScript {$_.Version -eq $moduleToLoad.ModuleVersion}
@@ -531,7 +545,7 @@ function ConvertTo-DSCObject
             {
                 $currentResources = $currentResources | Where-Object -FilterScript {$_.Version -eq $moduleToLoad.ModuleVersion}
             }
-            $DSCResources += $currentResources
+            $Script:DSCResources += $currentResources
         }
     }
 
@@ -571,7 +585,7 @@ function ConvertTo-DSCObject
         $currentResourceInfo.Add("ResourceInstanceName", $resourceInstanceName)
 
         # Get a reference to the current resource.
-        $currentResource = $DSCResources | Where-Object -FilterScript {$_.Name -eq $resourceType}
+        $currentResource = $Script:DSCResources | Where-Object -FilterScript {$_.Name -eq $resourceType}
 
         # Loop through all the key/pair value
         foreach ($keyValuePair in $resource.CommandElements[2].KeyValuePairs)


### PR DESCRIPTION
This PR fixes an issue where a CIM class receives an update to its properties and was already instantiated previously without the updated properties. In this case, the CIM class will be known and there is no discovery if the updated properties are properly reflected in the CIM class definition, leading to an error during parsing for those updated or newly added properties. 

```powershell
VERBOSE: Perform operation 'Get CimClass' with following parameters, ''namespaceName' = ROOT/Microsoft/Windows/DesiredStateConfiguration,'className' = MSFT_DeviceManagementConfigurationPolicyAssignments'.
VERBOSE: Operation 'Get CimClass' complete.
Invoke-Expression : At line:1 char:67
+ ...                                        $typeStaticMethods = [] | gm - ...
+
Missing type name after '['.
At line:4 char:50
+                                                 []::TryParse($subExpr ...
+
Missing type name after '['.
At C:\Program Files\WindowsPowerShell\Modules\DSCParser\2.0.0.17\Modules\DSCParser.psm1:400 char:29                                                                  + ...                       Invoke-Expression -Command $scriptBlock | Out-N ...
+                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : ParserError: (:) [Invoke-Expression], ParseException
+ FullyQualifiedErrorId : MissingTypename,Microsoft.PowerShell.Commands.InvokeExpressionCommand 
```

The PR fixes this issue by evaluating the current resource, fetching its schema.mof definition, parsing the version (if it contains one) and if the version in the CIM class definition is lower than in the schema, it will invoke the dummy resource to push the changes to the CIM class. For improved performance, the schema definition as well as the DSC resource information is cached across all resources. 