### PR TITLE
Quote dollar-prefixed strings that are not variable references

### DIFF
--- a/src/DSCParser.CSharp/DscParser.cs
+++ b/src/DSCParser.CSharp/DscParser.cs
@@ -36,6 +36,14 @@ namespace DSCParser.CSharp
 
         private const string ImportDscResourcePlaceholder = "DscParserImportDscResource";
 
+        // Matches a string that is syntactically nothing but a variable reference,
+        // optionally scoped and with member access: $name, $scope:name, $config.Credential.
+        // Anything else that merely starts with '$' (e.g. "$OrganizationName\Default")
+        // must be emitted quoted or the generated text does not reparse.
+        private static readonly Regex BareVariableReferenceRegex = new(
+            @"^\$(?:\w+:)?\w+(?:\.\w+)*$",
+            RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
         /// <summary>
         /// Receives non-fatal diagnostics such as unresolvable modules. When unset, they are dropped
         /// rather than written to the console, which would corrupt a PowerShell host's output stream.
@@ -905,8 +913,8 @@ namespace DSCParser.CSharp
             {
                 case string strValue:
                     AppendPropertyPrefix(result, property, additionalSpaces, childSpacer);
-                    // A string starting with $ and containing no spaces is a variable reference, not a literal
-                    if (strValue.StartsWith("$", StringComparison.Ordinal) && !strValue.StartsWith("$($", StringComparison.Ordinal) && !strValue.Contains(' '))
+                    // Only a string that is entirely a variable reference is emitted bare
+                    if (BareVariableReferenceRegex.IsMatch(strValue))
                     {
                         _ = result.AppendLine(strValue);
                     }

--- a/src/DSCParser.Tests/DscParserConvertFromDscObjectTests.cs
+++ b/src/DSCParser.Tests/DscParserConvertFromDscObjectTests.cs
@@ -119,6 +119,44 @@ public class DscParserConvertFromDscObjectTests
         Assert.DoesNotContain("\"$ConfigData.Credential\"", result);
     }
 
+    [Theory]
+    [InlineData("$OrganizationName\\Default")]
+    [InlineData("$Price=100")]
+    [InlineData("$(Get-Date)")]
+    public void ConvertFromDscObject_DollarStringThatIsNotAVariable_ShouldBeQuoted(string value)
+    {
+        var entries = new List<Hashtable>
+        {
+            new()
+            {
+                ["CIMInstance"] = "Test",
+                ["Identity"] = value
+            }
+        };
+
+        string result = DscParser.ConvertFromDscObject(entries, 1);
+
+        Assert.Contains($"\"{value}\"", result);
+    }
+
+    [Fact]
+    public void ConvertFromDscObject_ScopedVariableString_ShouldNotBeQuoted()
+    {
+        var entries = new List<Hashtable>
+        {
+            new()
+            {
+                ["CIMInstance"] = "Test",
+                ["Credential"] = "$script:Credential"
+            }
+        };
+
+        string result = DscParser.ConvertFromDscObject(entries, 1);
+
+        Assert.Contains("= $script:Credential", result);
+        Assert.DoesNotContain("\"$script:Credential\"", result);
+    }
+
     [Fact]
     public void ConvertFromDscObject_IntegerProperty_ShouldNotBeQuoted()
     {


### PR DESCRIPTION
Fixes #99.

`AppendProperty` treated any space-free string starting with `$` as a variable reference and emitted it bare, so string literals like `EXOEmailTenantSettings`' `Identity = "$OrganizationName\Default"` (a real Microsoft365DSC Exchange export value) regenerated as unquoted text that fails `ConvertTo-DSCObject` with `Unexpected token '\Default'`. #89 previously narrowed the same heuristic for `$($` subexpressions; this replaces the guesswork with a syntactic match so the whole class is covered.

A string is now emitted bare only when it is entirely a variable reference — `$name`, `$scope:name`, or member access such as `$ConfigData.Credential` (`^\$(?:\w+:)?\w+(?:\.\w+)*$`). Everything else goes through `AppendQuoted`, whose double-quoted output reparses to the identical value, including expandable strings that reference variables.

Tests: new cases assert `$OrganizationName\Default`, `$Price=100`, and `$(Get-Date)` are quoted while `$script:Credential` stays bare; the existing `ConvertFromDscObject_VariableString_ShouldNotBeQuoted` test (`$ConfigData.Credential`) still passes, as does the full suite.

Validation beyond unit tests: a real 601-instance Microsoft365DSC tenant export (AAD/Intune/EXO/O365/Viva) run through `ConvertTo-DSCObject` → `ConvertFrom-DSCObject` → `ConvertTo-DSCObject` inside the `microsoft365dsc:1.26.805.2-linux` image. Stock 3.0.0.5 and stock dev (8f15ec4) both fail with the `\Default` parse error; with this change the round trip completes — byte-identical on 3.0.0.5, and identical values on dev (only CIM-instance property *ordering* differs there, which appears to come from the #94 refactor and is unrelated to this change).
